### PR TITLE
removed context.Database.Migrate from Program.cs

### DIFF
--- a/AdoptAMonsterSite/Program.cs
+++ b/AdoptAMonsterSite/Program.cs
@@ -21,8 +21,7 @@ using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
     var context = services.GetRequiredService<ApplicationDbContext>();
-    context.Database.Migrate(); // Optional: applies any pending migrations
-    DbInitializer.Seed(context); // Your custom seeding method
+    DbInitializer.Seed(context);
 }
 
 


### PR DESCRIPTION
closes #40 

During testing when removing all listings and re-runing the program the home page automatically adds the monsters in the initializer but no longer applies any migration.