### PR TITLE
Replace Price with AdoptionFee in MonstersController

### DIFF
--- a/AdoptAMonsterSite/Controllers/MonstersController.cs
+++ b/AdoptAMonsterSite/Controllers/MonstersController.cs
@@ -54,7 +54,7 @@ namespace AdoptAMonsterSite.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Id,Name,Species,Description,Price")] Monster monster)
+        public async Task<IActionResult> Create([Bind("Id,Name,Species,Description,AdoptionFee")] Monster monster)
         {
             if (ModelState.IsValid)
             {
@@ -86,7 +86,7 @@ namespace AdoptAMonsterSite.Controllers
         // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Species,Description,Price")] Monster monster)
+        public async Task<IActionResult> Edit(int id, [Bind("Id,Name,Species,Description,AdoptionFee")] Monster monster)
         {
             if (id != monster.Id)
             {


### PR DESCRIPTION
Closes #54 

Updated the `Create` and `Edit` methods in the `MonstersController` class to replace the `Price` property with the `AdoptionFee` property in the `[Bind]` attribute. This ensures that the `AdoptionFee` property is properly included in the model binding process for creating and editing `Monster` objects.