### PR TITLE
Added the feature to remove the old images after delete and edit

### DIFF
--- a/AdoptAMonsterSite/AdoptAMonsterSite.csproj
+++ b/AdoptAMonsterSite/AdoptAMonsterSite.csproj
@@ -24,8 +24,4 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\images\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Closes #60 

This pull request improves how monster images are managed during edit and delete operations in the application. The main changes ensure that old image files are properly deleted when a monster's image is updated or the monster is deleted, and that the correct entity is updated in the database.

**Image management improvements:**

* When editing a monster, the code now loads the existing entity from the database, deletes the old image file if present, and assigns the new image filename to the existing entity instead of the incoming model. This ensures that the file system and database stay in sync.
* When deleting a monster, the code now attempts to delete the associated image file from disk before removing the monster from the database, handling errors gracefully to avoid blocking the operation.